### PR TITLE
Revise the generated argone-tempmon

### DIFF
--- a/argon1.sh
+++ b/argon1.sh
@@ -587,13 +587,20 @@ echo "*****************************************************"
 
 argon_create_file $tempmonscript
 
-echo 'while true; do clear; date; echo "$(( $(cat /sys/class/thermal/thermal_zone0/temp) / 1000 ))°C"; sleep 1 ; done' >> $tempmonscript
+(cat <<TEMPMONSCRIPT
+#! /usr/bin/env bash
+
+while true; do
+    date
+    echo "$(( $(cat /sys/class/thermal/thermal_zone0/temp) / 1000 ))°C"
+    sleep 1
+    # Go back up two lines.
+    echo -ne "\033[2A"
+done
+TEMPMONSCRIPT
+) > $tempmonscript
 
 sudo chmod 755 $tempmonscript
-
-
-
-
 
 
 echo "***************************"


### PR DESCRIPTION
The previously-generated `argone-tempmon` didn't have a shebang (`!#`) line at the beginning, and so wasn't directly executable. This commit fixes that. It also revises the update logic: instead of clearing the entire screen, `argone-tempmon` now uses a cursor-movement escape code to just redraw its output in the same place. This avoids the blinking that results from using `clear`.

Note that this differs from the other inline scripts in two ways:

1. It invokes `bash` via `/usr/bin/env` instead of directly.
2. It uses HEREDOC functionality to embed the script, instead of a succession of `echo <LINE> >> output_file` invocations.

I hope that's acceptable. Please let me know if it isn't. (If you'd like me to revise the other script-generation instances for consistency, please let me know that as well: I'd be happy to.)