### PR TITLE
don't evaluate inside double quotes for tempmonscript generation

### DIFF
--- a/argon1.sh
+++ b/argon1.sh
@@ -587,7 +587,7 @@ echo "*****************************************************"
 
 argon_create_file $tempmonscript
 
-(cat <<TEMPMONSCRIPT
+(cat <<'TEMPMONSCRIPT'
 #! /usr/bin/env bash
 
 while true; do


### PR DESCRIPTION
closes #12

looking over some [here](https://en.wikipedia.org/wiki/Here_document) documentation, it looks like if you don't quote the label you evaluate things inside the double quotes

in order to avoid that, we quote the starting label

this results in the tempmon including the script and not the literal temp value present during installation