### PR TITLE
Don't hardcode temp into tempmon script.

### DIFF
--- a/argon1.sh
+++ b/argon1.sh
@@ -592,7 +592,7 @@ argon_create_file $tempmonscript
 
 while true; do
     date
-    echo "$(( $(cat /sys/class/thermal/thermal_zone0/temp) / 1000 ))°C"
+    echo "\$(( \$(cat /sys/class/thermal/thermal_zone0/temp) / 1000 ))°C"
     sleep 1
     # Go back up two lines.
     echo -ne "\033[2A"


### PR DESCRIPTION
Was reading the temperature at the time argon1.sh script was run and
hardcoding the temp at that time into the tempmon script. Just needed a
little escaping.